### PR TITLE
Improved babel preset detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,7 @@ export default {
 If you use the `es2015` preset, make sure you install `es2015-rollup` too. See
 this project's own [`rollup.config.js`][rollup-config] for an example.
 
+For any presets you use in `.babelrc`, this module will look for one with the
+same name but with a `-rollup` suffix.
+
 [rollup-config]: https://github.com/eventualbuddha/babelrc-rollup/blob/master/rollup.config.js

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
+  },
+  "dependencies": {
+    "resolve": "^1.1.7"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ let pkg = require('./package.json');
 export default {
   entry: 'src/index.js',
   plugins: [babel(babelrc())],
-  external: ['fs'],
+  external: Object.keys(pkg['dependencies']).concat(['fs']),
   targets: [
     {
       dest: pkg['jsnext:main'],

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { readFileSync } from 'fs';
+import { sync as resolve } from 'resolve';
 
 function startsWith(string: string, prefix: string): boolean {
   return string.lastIndexOf(prefix, 0) === 0;
@@ -48,9 +49,7 @@ export function configWithoutModules(config: BabelConfig): BabelConfig {
     if (Object.prototype.hasOwnProperty.call(config, key)) {
       if (key === 'presets' && config.presets) {
         // Replace the es2015 preset with the es2015-rollup preset.
-        result.presets = config.presets.map(
-          preset => preset === 'es2015' ? 'es2015-rollup' : preset
-        );
+        result.presets = config.presets.map(mapPreset);
       } else if (key === 'plugins' && config.plugins) {
         // Remove any explicit module plugins, e.g. es2015-modules-commonjs.
         result.plugins = config.plugins.filter(
@@ -66,4 +65,14 @@ export function configWithoutModules(config: BabelConfig): BabelConfig {
   result.babelrc = false;
 
   return result;
+}
+
+function mapPreset(preset: string): string {
+  try {
+    // this will throw if it can't resolve it
+    resolve(`babel-preset-${preset}-rollup`);
+    return `${preset}-rollup`;
+  } catch (err) {
+    return preset;
+  }
 }


### PR DESCRIPTION
BREAKING CHANGE

This will differ in behavior since it may use presets that you didn’t expect. The previous version only used es2015-rollup in lieu of es2015.

Closes #1
