### PR TITLE
Add `presetsToAddModuleOptions` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules/

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,10 @@ function startsWith(string: string, prefix: string): boolean {
   return string.lastIndexOf(prefix, 0) === 0;
 }
 
+function includes<T>(array: Array<T>, value: T): boolean {
+  return array.indexOf(value) > -1;
+}
+
 type Preset = any;
 
 type BabelConfig = {
@@ -46,6 +50,7 @@ type Options = {
   findRollupPresets?: boolean;
   addModuleOptions?: boolean;
   addExternalHelpersPlugin?: boolean;
+  presetsToAddModuleOptions?: Array<string>,
   resolve?: (path: string) => string;
 };
 
@@ -54,6 +59,7 @@ const DEFAULT_OPTIONS = {
   findRollupPresets: false,
   addModuleOptions: true,
   addExternalHelpersPlugin: true,
+  presetsToAddModuleOptions: ['env', 'es2015'],
   resolve
 };
 
@@ -111,9 +117,14 @@ function mapPreset(preset: any, options: Options): any {
     return preset;
   }
 
+  const {presetsToAddModuleOptions} = options;
+  if (!presetsToAddModuleOptions) {
+    throw new Error('Option "presetsToAddModuleOptions" should have default option');
+  }
+
   if (options.findRollupPresets && hasRollupVersionOfPreset(info.name, options.resolve || resolve)) {
     return [`${info.name}-rollup`, info.options];
-  } else if (options.addModuleOptions) {
+  } else if (options.addModuleOptions && includes(presetsToAddModuleOptions, info.name)) {
     return [info.name, { ...info.options, modules: false }];
   } else {
     return preset;

--- a/test/test.js
+++ b/test/test.js
@@ -70,7 +70,7 @@ describe('babelrc-rollup', () => {
       }).presets,
       [
         ['foo-rollup', {}],
-        ['bar', { modules: false }]
+        'bar'
       ]
     )
   });
@@ -96,6 +96,35 @@ describe('babelrc-rollup', () => {
         addExternalHelpersPlugin: false
       }).plugins,
       []
+    );
+  });
+
+  it('adds modules: false to "env" and "es2015" preset by default', () => {
+    deepEqual(
+      babelrc({
+        config: {
+          presets: ['env', 'es2015', 'flow']
+        }
+      }).presets,
+      [
+        ['env', {modules: false}],
+        ['es2015', {modules: false}],
+        'flow'
+      ]
+    );
+  });
+
+  it('adds modules: false to presets in `presetsToAddModuleOptions` option', () => {
+    deepEqual(
+      babelrc({
+        config: {
+          presets: ['foo']
+        },
+        presetsToAddModuleOptions: ['foo']
+      }).presets,
+      [
+        ['foo', {modules: false}]
+      ]
     );
   });
 });


### PR DESCRIPTION
This PR is a proposed approach to fix https://github.com/eventualbuddha/babelrc-rollup/issues/6 issue.

It changes default behaviour. New major version will be needed if it will be merged. It provides a way to fallback to previous behaviour with `presetsToAddModuleOptions` option.

Please don't hesitate to add any comments.